### PR TITLE
Fix run commands

### DIFF
--- a/docker-configurations/README.md
+++ b/docker-configurations/README.md
@@ -51,7 +51,7 @@ docker image pull ghcr.io/agile-learning-institute/mentorhub-person-ui:latest
 ### Run the person triplet
 
 ```bash
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person
 ```
 
 You can now use the [Access paths](https://github.com/agile-learning-institute/mentorhub-person-ui#access-paths) documented in the [mentorhub-person-ui](https://github.com/agile-learning-institute/mentorhub-person-ui) repository.
@@ -59,7 +59,7 @@ You can now use the [Access paths](https://github.com/agile-learning-institute/m
 ### Run the person api and backing database
 
 ```bash
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person-api
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) person-api
 ```
 
 You can now use the [Curl Commands](https://github.com/agile-learning-institute/mentorhub-person-api#local-api-testing-with-curl) documented in the [mentorhub-person-api](https://github.com/agile-learning-institute/mentorhub-person-api) repository.
@@ -67,7 +67,7 @@ You can now use the [Curl Commands](https://github.com/agile-learning-institute/
 ### Run the MongoDB backing database
 
 ```bash
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) db
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) db
 ```
 
 You can now use [Mongo Compass](https://github.com/agile-learning-institute/mentorhub-mongodb#optionally) as documented in the [mentorhub-mongodb](https://github.com/agile-learning-institute/mentorhub-mongodb) repository.


### PR DESCRIPTION
The prior syntax is specific to zsh and creates a true temporary file. This change allows the commands to run on bash as well.