### PR TITLE
Make run-local self-cleaning

### DIFF
--- a/docker-configurations/run-local.sh
+++ b/docker-configurations/run-local.sh
@@ -8,15 +8,15 @@ curl --create-dirs --output "$compose_dir/docker-compose.yaml" https://raw.githu
 docker compose --project-directory "$compose_dir" up --detach && {
 
 
-cat > compose-down.sh << EOF
+cat > /tmp/compose-down.sh << EOF
 #!/bin/sh
 
 docker compose --project-directory "$compose_dir" --profile "$1" down && rm -r "$compose_dir" && rm "\$0"
 EOF
 
 
-chmod u+x compose-down.sh
+chmod u+x /tmp/compose-down.sh
 
-echo "To stop the containers, just execute compose-down.sh"
+echo "To stop the containers, just execute /tmp/compose-down.sh"
 
 }

--- a/docker-configurations/run-local.sh
+++ b/docker-configurations/run-local.sh
@@ -6,7 +6,7 @@ compose_dir="$(mktemp -d)"
 
 [ -f /tmp/compose-down.sh ] && /tmp/compose-down.sh
 curl --create-dirs --output "$compose_dir/docker-compose.yaml" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml
-docker compose --project-directory "$compose_dir" up --detach && {
+docker compose --project-directory "$compose_dir" up --detach
 
 
 cat > /tmp/compose-down.sh << EOF
@@ -19,5 +19,3 @@ EOF
 chmod u+x /tmp/compose-down.sh
 
 echo "To stop the containers, just execute /tmp/compose-down.sh"
-
-}

--- a/docker-configurations/run-local.sh
+++ b/docker-configurations/run-local.sh
@@ -2,6 +2,22 @@ if [ ! -z "$1" ]; then
 	export COMPOSE_PROFILES="$1"
 fi
 
-docker compose --project-directory ~/local down
-curl --create-dirs --output ~/local/docker-compose.yaml https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml
-docker compose --project-directory ~/local up --detach
+compose_dir="$(mktemp -d)"
+
+docker compose --project-directory "$compose_dir" down
+curl --create-dirs --output "$compose_dir/docker-compose.yaml" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml
+docker compose --project-directory "$compose_dir" up --detach && {
+
+
+cat > compose-down.sh << EOF
+#!/bin/sh
+
+docker compose --project-directory "$compose_dir" --profile "$1" down && rm -r "$compose_dir" && rm "\$0"
+EOF
+
+
+chmod u+x compose-down.sh
+
+echo "To stop the containers, just execute compose-down.sh"
+
+}

--- a/docker-configurations/run-local.sh
+++ b/docker-configurations/run-local.sh
@@ -4,6 +4,7 @@ fi
 
 compose_dir="$(mktemp -d)"
 
+[ -f /tmp/compose-down.sh ] && /tmp/compose-down.sh
 curl --create-dirs --output "$compose_dir/docker-compose.yaml" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml
 docker compose --project-directory "$compose_dir" up --detach && {
 

--- a/docker-configurations/run-local.sh
+++ b/docker-configurations/run-local.sh
@@ -4,7 +4,6 @@ fi
 
 compose_dir="$(mktemp -d)"
 
-docker compose --project-directory "$compose_dir" down
 curl --create-dirs --output "$compose_dir/docker-compose.yaml" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml
 docker compose --project-directory "$compose_dir" up --detach && {
 


### PR DESCRIPTION
Updates `run-local.sh` to download the compose file to a temporary directory and creates a script ~~in the user's current working directory~~ called `/tmp/compose-down.sh`, which reverts everything back to the way it was before the command was run (calls `docker compose down` to stop the service which was run, then deletes the temporary directory, after which the `compose-down.sh` script "self-destructs" by deleting itself)

`compose-down.sh` could also be created in $HOME. Choice of /tmp is not terribly important

Would close #35 