### PR TITLE
Add mh clean command

### DIFF
--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -46,8 +46,11 @@ COMMANDS
     reset
         delete all mh containers - usefull to reset mh if things get hosed
 
+    clean
+        Delete mentorHub-specific containers and images
+
     purge
-        delete all mh containers and images
+        delete all docker containers and images
 
     version
         print the mentorHub-DE version
@@ -87,7 +90,8 @@ Commands:
   stop        Stop a profile
   update      Update the mentorHub Developer Edition
   reset       Delete all mh containers
-  purge       Delete all mh containers and images
+  clean       Delete mentorHub-specific containers and images
+  purge       Delete all docker containers and images
   version     Print the mentorHub-DE version
   logs        Tail the log file (use ^C to escape)
   current     Print the current profile
@@ -281,6 +285,36 @@ function deleteImages {
 }
 
 ################################################################################
+# Clean up images and containers
+################################################################################
+function clean {
+    echo "clean" >> $INSTALL_PATH/logs
+
+    docker compose -f $INSTALL_PATH/docker-compose.yaml ps -a --format '{{ .Names }}' | while read -r container; do
+        echo "- removing container $container" >> "$INSTALL_PATH/logs"
+        echo "- removing container $container"
+        docker container rm -f "$container" > /dev/null 2>&1
+    done
+
+    docker compose -f "$INSTALL_PATH/docker-compose.yaml" --profile '*' config --images | while read -r image; do
+        echo "- removing image $image" >> $INSTALL_PATH/logs
+        echo "- removing image $image"
+        docker image rm -f "$image"  2>>&1 $INSTALL_PATH/logs
+    done
+
+    docker volume ls | awk 'NR > 1 {print $2}' | while read -r volume; do
+        echo "- removing volume $volume" >> $INSTALL_PATH/logs
+        echo "- removing volume $volume"
+        docker volume rm -f "$volume" 2>>&1 $INSTALL_PATH/logs
+    done
+
+    echo "clean Successful" >> $INSTALL_PATH/logs
+
+    echo > "$INSTALL_PATH/CURRENT"
+    echo "$(date) RESET - Logs Reset" > "$INSTALL_PATH/logs"
+}
+
+################################################################################
 # Uninstall mentorHub-DE
 ################################################################################
 function uninstall {
@@ -329,6 +363,11 @@ case $COMMAND in
   "reset")
 
     deleteContainers
+    ;;
+
+  "clean")
+
+    clean
     ;;
 
   "purge")


### PR DESCRIPTION
Currently this deletes all images referenced in the compose file. One possible enhancement would be to only delete images matching `agile-learning-institute`, thereby leaving third-party images untouched.

Would close #89