### PR TITLE
100 reduce feature bloat

### DIFF
--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -354,7 +354,7 @@ case $COMMAND in
 
   "version")
 
-    echo "v1.1.1"
+    echo "v2.0.0"
     ;;
 
   "list-profiles")

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -57,6 +57,9 @@ COMMANDS
 
     version
         print the mentorHub-DE version
+    
+    list-profiles
+        List all available profiles related to mentorhub-DE
 
     uninstall
         Removes mentorHub-DE completely
@@ -80,6 +83,7 @@ Commands:
   update         Update the mentorHub Developer Edition
   clean          Delete mentorHub-specific containers and images
   version        Print the mentorHub-DE version
+  list-profiles  List all available profiles
   manual         Show the manual
   uninstall      Remove mh and all associated files
 END
@@ -109,6 +113,15 @@ function checkAndStartDocker {
     fi
 }
 
+################################################################################
+# Print list of all profiles
+################################################################################
+function listProfiles {
+    echo "listProfiles" >> "$INSTALL_PATH/logs"
+    PROFILES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" config --profiles)
+    echo "Available profiles:"
+    echo $PROFILES
+}
 ################################################################################
 # Get the currently running profile
 ################################################################################
@@ -383,6 +396,11 @@ case $COMMAND in
   "version")
 
     echo "v1.1.1"
+    ;;
+
+  "list-profiles")
+
+    listProfiles
     ;;
 
   "manual")

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -174,7 +174,7 @@ function upProfile {
         echo "Docker compose command failed with status $docker_compose_status"
         listProfiles
     fi
-    if [[ -n $(<"$INSTALL_PATH/CURRENT") ]]; then
+    if [[ -s "$INSTALL_PATH/CURRENT" ]]; then
         echo "${NEW_PROFILE}" >> "$INSTALL_PATH/CURRENT"
     else 
         echo "${NEW_PROFILE}" > "$INSTALL_PATH/CURRENT"

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -213,7 +213,11 @@ function startCurrent {
 # docker compose logs
 ################################################################################
 function tailServiceLogs {
-    echo "startTail ${NEW_PROFILE[@]}" >> $INSTALL_PATH/logs
+        if [[ -z $NEW_PROFILE ]]; then
+        listServices
+        echo "No service provided, exiting with exit code 1"
+        return 1
+    fi
     if [[ -n $NEW_PROFILE ]]; then
         docker_compose_args=("--project-directory" "$INSTALL_PATH" "logs")
         for profile in "${NEW_PROFILE[@]}"; do

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -122,6 +122,7 @@ function listProfiles {
     echo "Available profiles:"
     echo $PROFILES
 }
+
 ################################################################################
 # Get the currently running profile
 ################################################################################
@@ -138,47 +139,6 @@ function getCurrentProfile {
 }
 
 ################################################################################
-# Validate new Profile, prompt for valid profile
-################################################################################
-function getNewProfile {
-    echo "getNewProfile" >> "$INSTALL_PATH/logs"
-    local validProfile=0
-    if [[ "$NEW_PROFILE" != *","* ]]; then 
-        # Populate the PROFILES variable
-        PROFILES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" config --profiles)
-
-        # First, check if NEW_PROFILE is already valid
-        OLD_IFS=$IFS
-        while IFS= read -r profile; do
-            if [[ $NEW_PROFILE == $profile ]]; then
-                validProfile=1
-                break
-            fi
-        done <<< "$PROFILES"
-        IFS=$OLD_IFS
-
-        # If NEW_PROFILE is not valid, prompt the user to select a valid profile
-        while [[ $validProfile -eq 0 ]]; do
-            echo "Please select a profile from the following:"
-            nl -w 3 -s ') ' <<< "$PROFILES"
-            echo -n "Select the profile: "
-            read -r inputProfile
-            if [[ $inputProfile -ge 1 && $inputProfile -le $(wc -l <<< "$PROFILES") ]]; then
-                NEW_PROFILE=$(sed -n "${inputProfile}p" <<< "$PROFILES")
-                validProfile=1
-            else
-                echo "Invalid profile: $inputProfile. Please try again."
-            fi
-        done
-    else
-    # Split comma-separated list into an array
-        NEW_PROFILE=( ${(s:,:)NEW_PROFILE} )
-        validProfile=1
-    fi
-    echo "New Profile set $NEW_PROFILE" >> "$INSTALL_PATH/logs"
-}
-
-################################################################################
 # docker compose down of current profile
 ################################################################################
 function downCurrent {
@@ -186,10 +146,10 @@ function downCurrent {
     getCurrentProfile
     echo "downCurrent ${CURRENT_PROFILES[@]}" >> $INSTALL_PATH/logs
     if [[ -n $CURRENT_PROFILES ]]; then
-    docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
-    for profile in "${CURRENT_PROFILES[@]}"; do
-        docker_compose_args+=("--profile" "$profile")
-    done
+        docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
+        for profile in "${CURRENT_PROFILES[@]}"; do
+            docker_compose_args+=("--profile" "$profile")
+        done
         docker compose "${docker_compose_args[@]}" down
         docker volume prune -f
         echo > "$INSTALL_PATH/CURRENT"
@@ -201,17 +161,16 @@ function downCurrent {
 # docker compose up of current profile
 ################################################################################
 function upProfile {
-    getNewProfile
     docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
-    for profile in "${NEW_PROFILE[@]}"; do
+    for profile in "${(s:,:)NEW_PROFILE}"; do
         docker_compose_args+=("--profile" "$profile")
     done
     echo "upProfile $NEW_PROFILE" >> $INSTALL_PATH/logs
     docker compose "${docker_compose_args[@]}" up --detach
     if [[ -n $(<"$INSTALL_PATH/CURRENT") ]]; then
-        echo "${NEW_PROFILE[@]}" >> "$INSTALL_PATH/CURRENT"
+        echo "${NEW_PROFILE}" >> "$INSTALL_PATH/CURRENT"
     else 
-        echo "${NEW_PROFILE[@]}" > "$INSTALL_PATH/CURRENT"
+        echo "${NEW_PROFILE}" > "$INSTALL_PATH/CURRENT"
     fi
     echo "upProfile Successful" >> $INSTALL_PATH/logs
 }
@@ -227,7 +186,7 @@ function stopCurrent {
         for profile in "${CURRENT_PROFILES[@]}"; do
             docker_compose_args+=("--profile" "$profile")
         done
-    docker compose "${docker_compose_args[@]}" stop
+        docker compose "${docker_compose_args[@]}" stop
     fi
     echo "stopCurrent Successful" >> $INSTALL_PATH/logs
 }
@@ -240,9 +199,9 @@ function startCurrent {
     echo "startProfile $CURRENT_PROFILES" >> $INSTALL_PATH/logs
     if [[ -n $CURRENT_PROFILES ]]; then
         docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
-            for profile in "${CURRENT_PROFILES[@]}"; do
-                docker_compose_args+=("--profile" "$profile")
-            done
+        for profile in "${CURRENT_PROFILES[@]}"; do
+            docker_compose_args+=("--profile" "$profile")
+        done
         docker compose "${docker_compose_args[@]}" start 
     fi
     echo "startCurrent Successful" >> $INSTALL_PATH/logs

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -94,8 +94,6 @@ END
 # Make sure Docker is running
 ################################################################################
 function checkAndStartDocker {
-    echo "checkAndStartDocker" >> $INSTALL_PATH/logs
-
     if ! docker info >/dev/null 2>&1; then
         echo "Docker is not running. Attempting to start Docker..."
         if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -118,7 +116,6 @@ function checkAndStartDocker {
 # Print list of all profiles
 ################################################################################
 function listProfiles {
-    echo "listProfiles" >> "$INSTALL_PATH/logs"
     PROFILES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" config --profiles)
     echo "Available profiles:"
     echo $PROFILES
@@ -128,7 +125,6 @@ function listProfiles {
 # Print list of all profiles
 ################################################################################
 function listServices {
-    echo "listServices" >> "$INSTALL_PATH/logs"
     SERVICES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" --profile '*' config --services)
     echo "Available services:"
     echo $SERVICES
@@ -138,7 +134,6 @@ function listServices {
 # Get the currently running profile
 ################################################################################
 function getCurrentProfile {
-    echo "getCurrentProfile" >> $INSTALL_PATH/logs
     CURRENT_PROFILES=()
     if [[ -f "$INSTALL_PATH/CURRENT" ]]; then
         OLD_IFS=$IFS
@@ -146,16 +141,14 @@ function getCurrentProfile {
         CURRENT_PROFILES=( $(<"$INSTALL_PATH/CURRENT") )
         IFS=$OLD_IFS
     fi
-    echo "CurrentProfile set: ${CURRENT_PROFILES[@]}" >> $INSTALL_PATH/logs
+    echo "CurrentProfile set: ${CURRENT_PROFILES[@]}"
 }
 
 ################################################################################
 # docker compose down of current profile
 ################################################################################
 function downCurrent {
-    checkAndStartDocker
     getCurrentProfile
-    echo "downCurrent ${CURRENT_PROFILES[@]}" >> $INSTALL_PATH/logs
     if [[ -n $CURRENT_PROFILES ]]; then
         docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
         for profile in "${CURRENT_PROFILES[@]}"; do
@@ -164,7 +157,6 @@ function downCurrent {
         docker compose "${docker_compose_args[@]}" down
         docker volume prune -f
         echo > "$INSTALL_PATH/CURRENT"
-        echo "downCurrent Successful" >> $INSTALL_PATH/logs
     fi
 }
 
@@ -176,7 +168,6 @@ function upProfile {
     for profile in "${(s:,:)NEW_PROFILE}"; do
         docker_compose_args+=("--profile" "$profile")
     done
-    echo "upProfile $NEW_PROFILE" >> $INSTALL_PATH/logs
     docker compose "${docker_compose_args[@]}" up --detach
     docker_compose_status=$?  # Capture the exit status of the docker compose command
     if [[ $docker_compose_status -ne 0 ]]; then
@@ -188,7 +179,6 @@ function upProfile {
     else 
         echo "${NEW_PROFILE}" > "$INSTALL_PATH/CURRENT"
     fi
-    echo "upProfile Successful" >> $INSTALL_PATH/logs
 }
 
 ################################################################################
@@ -196,7 +186,6 @@ function upProfile {
 ################################################################################
 function stopCurrent {
     getCurrentProfile
-    echo "stopCurrent $CURRENT_PROFILES" >> $INSTALL_PATH/logs
     if [[ -n $CURRENT_PROFILES ]]; then
         docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
         for profile in "${CURRENT_PROFILES[@]}"; do
@@ -204,7 +193,6 @@ function stopCurrent {
         done
         docker compose "${docker_compose_args[@]}" stop
     fi
-    echo "stopCurrent Successful" >> $INSTALL_PATH/logs
 }
 
 ################################################################################
@@ -212,7 +200,6 @@ function stopCurrent {
 ################################################################################
 function startCurrent {
     getCurrentProfile
-    echo "startProfile $CURRENT_PROFILES" >> $INSTALL_PATH/logs
     if [[ -n $CURRENT_PROFILES ]]; then
         docker_compose_args=("--project-directory" "$INSTALL_PATH" "-f" "$INSTALL_PATH/docker-compose.yaml")
         for profile in "${CURRENT_PROFILES[@]}"; do
@@ -220,7 +207,6 @@ function startCurrent {
         done
         docker compose "${docker_compose_args[@]}" start 
     fi
-    echo "startCurrent Successful" >> $INSTALL_PATH/logs
 }
 
 ################################################################################
@@ -240,7 +226,7 @@ function tailServiceLogs {
             listServices
         fi
     fi
-    echo "tail completed" >> $INSTALL_PATH/logs
+    echo "tail completed"
 }
 
 ################################################################################
@@ -248,56 +234,48 @@ function tailServiceLogs {
 ################################################################################
 function update {
     downCurrent
-    echo "update configurations" >> $INSTALL_PATH/logs
 
     echo "fetching docker-compose.yaml"
     curl -o "$INSTALL_PATH/docker-compose.yaml" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/docker-compose.yaml 2>> /dev/null
 
     echo "Pulling Images"
     docker compose -f "$INSTALL_PATH/docker-compose.yaml" --profile '*' config --images | while read -r image; do
-        echo "pulling $image" >> $INSTALL_PATH/logs 
         echo "pulling $image"
-        docker pull "$image" >> $INSTALL_PATH/logs 2>&1
+        docker pull "$image"
     done
 
     echo "Housekeeping orphaned images"
-    docker image prune -f 2>> $INSTALL_PATH/logs
+    docker image prune -f
 
     echo "fetching mh"
     curl -o "$INSTALL_PATH/mh" https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/mentorHub-developer-edition/mh 2>> /dev/null
 
-    echo "update Successful" >> $INSTALL_PATH/logs
+    echo "update Successful"
 }
 
 ################################################################################
 # force rm all containers
 ################################################################################
 function deleteContainers {
-    echo "deleteContainers" >> "$INSTALL_PATH/logs"
     docker compose -f $INSTALL_PATH/docker-compose.yaml ps -a --format '{{ .Names }}' | while read -r container; do
-        echo "- removing container $container" >> "$INSTALL_PATH/logs"
         echo "- removing container $container" 
         docker container rm -f "$container" > /dev/null 2>&1
     done
     echo > "$INSTALL_PATH/CURRENT"
-    echo "$(date) RESET - Logs Reset" > "$INSTALL_PATH/logs"
 }
 
 ################################################################################
 # force rm all images
 ################################################################################
 function deleteImages {
-    echo "deleteImages" >> $INSTALL_PATH/logs
     docker compose -f "$INSTALL_PATH/docker-compose.yaml" --profile '*' config --images | while read -r image; do
-        echo "- removing image $image" >> $INSTALL_PATH/logs
         echo "- removing image $image" 
-        docker image rm -f "$image"  2>>&1 $INSTALL_PATH/logs
+        docker image rm -f "$image"
     done
 
     docker volume ls | awk 'NR > 1 {print $2}' | while read -r volume; do
-        echo "- removing volume $volume" >> $INSTALL_PATH/logs
         echo "- removing volume $volume"
-        docker volume rm -f "$volume" 2>>&1 $INSTALL_PATH/logs
+        docker volume rm -f "$volume" 
     done
 
 }
@@ -306,16 +284,12 @@ function deleteImages {
 # Clean up images and containers
 ################################################################################
 function clean {
-    echo "clean" >> $INSTALL_PATH/logs
 
     deleteContainers
 
     deleteImages
 
-    echo "clean Successful" >> $INSTALL_PATH/logs
-
     echo > "$INSTALL_PATH/CURRENT"
-    echo "$(date) RESET - Logs Reset" > "$INSTALL_PATH/logs"
 }
 
 ################################################################################
@@ -333,7 +307,8 @@ function uninstall {
 
 ##########################################################################
 # Main 
-echo "$(date) mh start $COMMAND $NEW_PROFILE" >> "$INSTALL_PATH/logs"
+checkAndStartDocker
+echo "$(date) mh start $COMMAND $NEW_PROFILE"
 
 case $COMMAND in
 

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -59,10 +59,7 @@ COMMANDS
         print the mentorHub-DE version
     
     list-profiles
-        list all available profiles related to mentorhub-DE
-
-    list-services
-        list all services related to mentorhub
+        List all available profiles related to mentorhub-DE
 
     uninstall
         Removes mentorHub-DE completely
@@ -181,6 +178,11 @@ function upProfile {
     done
     echo "upProfile $NEW_PROFILE" >> $INSTALL_PATH/logs
     docker compose "${docker_compose_args[@]}" up --detach
+    docker_compose_status=$?  # Capture the exit status of the docker compose command
+    if [[ $docker_compose_status -ne 0 ]]; then
+        echo "Docker compose command failed with status $docker_compose_status"
+        listProfiles
+    fi
     if [[ -n $(<"$INSTALL_PATH/CURRENT") ]]; then
         echo "${NEW_PROFILE}" >> "$INSTALL_PATH/CURRENT"
     else 
@@ -232,6 +234,11 @@ function tailServiceLogs {
             docker_compose_args+=("-f" "$profile")
         done
         docker compose "${docker_compose_args[@]}"
+        docker_compose_status=$?  # Capture the exit status of the docker compose command
+        if [[ $docker_compose_status -ne 0 ]]; then
+            echo "Docker compose command failed with status $docker_compose_status"
+            listServices
+        fi
     fi
     echo "tail completed" >> $INSTALL_PATH/logs
 }

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -58,23 +58,8 @@ COMMANDS
     version
         print the mentorHub-DE version
 
-    logs
-        tail the mh log file, ^c to excape
-
-    current
-        print the current profile
-
-    setcurrent [profile]
-        set the current profile
-
     uninstall
         Removes mentorHub-DE completely
-
-PROFILES
-    mongodb - the backing mongo database
-    person-api - the API supporting the person UI and the mongodb
-    person-ui - the SPA for person, and the API and backing database
-
 END
 }
 
@@ -95,9 +80,6 @@ Commands:
   update         Update the mentorHub Developer Edition
   clean          Delete mentorHub-specific containers and images
   version        Print the mentorHub-DE version
-  logs           Tail the log file (use ^C to escape)
-  current        Print the current profile
-  setcurrent     Manually set the current profile
   manual         Show the manual
   uninstall      Remove mh and all associated files
 END
@@ -396,24 +378,6 @@ case $COMMAND in
   "clean")
 
     clean
-    ;;
-
-  "logs")
-
-    tail -f $INSTALL_PATH/logs
-    ;;
-
-  "current")
-
-    getCurrentProfile
-    echo $CURRENT_PROFILES
-    ;;
-
-  "setcurrent")
-
-    getNewProfile
-    echo "Setting Profile to $NEW_PROFILE"
-    echo "$NEW_PROFILE" >> "$INSTALL_PATH/CURRENT"
     ;;
 
   "version")

--- a/mentorHub-developer-edition/mh
+++ b/mentorHub-developer-edition/mh
@@ -59,7 +59,10 @@ COMMANDS
         print the mentorHub-DE version
     
     list-profiles
-        List all available profiles related to mentorhub-DE
+        list all available profiles related to mentorhub-DE
+
+    list-services
+        list all services related to mentorhub
 
     uninstall
         Removes mentorHub-DE completely
@@ -84,6 +87,7 @@ Commands:
   clean          Delete mentorHub-specific containers and images
   version        Print the mentorHub-DE version
   list-profiles  List all available profiles
+  list-services  List all available services
   manual         Show the manual
   uninstall      Remove mh and all associated files
 END
@@ -121,6 +125,16 @@ function listProfiles {
     PROFILES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" config --profiles)
     echo "Available profiles:"
     echo $PROFILES
+}
+
+################################################################################
+# Print list of all profiles
+################################################################################
+function listServices {
+    echo "listServices" >> "$INSTALL_PATH/logs"
+    SERVICES=$(docker compose -f "$INSTALL_PATH/docker-compose.yaml" --profile '*' config --services)
+    echo "Available services:"
+    echo $SERVICES
 }
 
 ################################################################################
@@ -360,6 +374,11 @@ case $COMMAND in
   "list-profiles")
 
     listProfiles
+    ;;
+
+    "list-services")
+    
+    listServices
     ;;
 
   "manual")


### PR DESCRIPTION
## I didn't remove any of the pipes to logs. I want a second opinion before I do that. 
### Changes so far:
- Removed `logs`, `current`, and `setcurrent` arguments
- Removed profile validation logic, now errors straight from docker. If there's a docker error, lists profiles.
- Added `list-services` and `list-profiles` arguments
- On docker error for `mh tail`, will call `listServices`
### Improvements to be made:
- [x] (Possibly) Remove all pipes to $INSTALL_PATH/logs
- [ ] Current behavior for `upProfile` and `tailServiceLogs` is if `docker compose` returns with a status of `1`,  they print their respective list of options. This means that if a container fails to start and errors out from `mh up`, `listProfiles` gets called. I'm not sure of a way to list profiles on an invalid entry without re-adding profile validation logic, unless we just let the user manually use `list-profiles`. 

Thoughts/feedback?